### PR TITLE
plain 아닌 jar 선택

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -165,7 +165,7 @@ jobs:
     - name: 백엔드 애플리케이션 실행 (백그라운드)
       working-directory: ./backend
       run: |
-        java -jar build/libs/*.jar &
+        java -jar build/libs/*[!-plain].jar &
         echo $! > app.pid
 
         # 백엔드가 완전히 시작될 때까지 헬스 엔드포인트를 폴링


### PR DESCRIPTION
 수정된 내용:
  - .github/workflows/main-ci.yml:168에서 java -jar build/libs/*.jar &를 java -jar build/libs/*[!-plain].jar &로 변경
  - 이제 -plain.jar 파일은 제외하고 실행 가능한 JAR 파일만 실행합니다

  해결된 문제:
  - Spring Boot는 두 개의 JAR를 생성하는데, *-plain.jar는 일반 라이브러리 JAR로 Main-Class가 없어서 실행할 수 없습니다
  - 변경된 패턴 *[!-plain].jar는 -plain으로 끝나지 않는 JAR 파일만 선택하여 실행 가능한 fat JAR를 정확히 실행합니다

---
Ticket:
Github: close #14